### PR TITLE
Add RANKING_URL config for review-score deep links and documentation

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -53,11 +53,11 @@ const CONFIG = {
   },
   // Review-score link template for PhoneSelector.
   // When empty (default), the review score renders as plain text (legacy behavior, no link).
-  // Placeholders: {brand}, {model}, {slug}, {fullName}, {type}. Values are URL-encoded.
+  // Placeholders: {brand}, {model}, {slug}, {fullName}. Values are URL-encoded.
   // If the template contains no placeholders, it is used verbatim.
-  // mGT does not track per-phone type — {type} always resolves to 'earphone'. For
-  // headphone-only deploys, hardcode '?type=headphone' in the template instead.
-  RANKING_URL: "",
+  // mGT does not track per-phone type. 
+  // For headphone-only deploys, hardcode '?type=headphone' in the template instead.
+  RANKING_URL: "/ranking/?type=earphone#{slug}",
   // CDN Deployment Settings (optional)
   // Uncomment this section ONLY if you are using the CDN deployment mode
   // with the thin cdn-index.html. When using the full dist/ deployment, leave this commented out.

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -51,6 +51,13 @@ const CONFIG = {
     AUTO_UPDATE_URL: true,                              // This will automatically update URL when phone/target is changed.
     COMPRESS_URL: true,                                 // Compresses URL with Base62 encoding
   },
+  // Review-score link template for PhoneSelector.
+  // When empty (default), the review score renders as plain text (legacy behavior, no link).
+  // Placeholders: {brand}, {model}, {slug}, {fullName}, {type}. Values are URL-encoded.
+  // If the template contains no placeholders, it is used verbatim.
+  // mGT does not track per-phone type — {type} always resolves to 'earphone'. For
+  // headphone-only deploys, hardcode '?type=headphone' in the template instead.
+  RANKING_URL: "",
   // CDN Deployment Settings (optional)
   // Uncomment this section ONLY if you are using the CDN deployment mode
   // with the thin cdn-index.html. When using the full dist/ deployment, leave this commented out.

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -57,7 +57,7 @@ const CONFIG = {
   // If the template contains no placeholders, it is used verbatim.
   // mGT does not track per-phone type. 
   // For headphone-only deploys, hardcode '?type=headphone' in the template instead.
-  RANKING_URL: "/ranking/?type=earphone#{slug}",
+  RANKING_URL: "",
   // CDN Deployment Settings (optional)
   // Uncomment this section ONLY if you are using the CDN deployment mode
   // with the thin cdn-index.html. When using the full dist/ deployment, leave this commented out.

--- a/docs/docs/guide-for-admins/customize-page.mdx
+++ b/docs/docs/guide-for-admins/customize-page.mdx
@@ -301,6 +301,38 @@ URL: {
   - When activated, the URL is compressed using the base62 algorithm.
   - Choose `true` or `false`.
 
+### `RANKING_URL`
+```JavaScript
+// Default — no link, review score renders as plain text:
+RANKING_URL: "",
+
+// Link to a squigRanking page on the same deploy, anchored to the device card:
+RANKING_URL: "/ranking/?type=earphone#{slug}",
+
+// External ranking page:
+RANKING_URL: "https://reviews.example.com/?type={type}#{slug}",
+
+// Raw URL with no per-device anchoring (no placeholders → used verbatim):
+RANKING_URL: "https://docs.google.com/spreadsheets/.../pubhtml",
+```
+Wraps the per-phone review score in the device selector with a clickable link to your ranking page (e.g. [squigRanking](https://github.com/potatosalad775/squigRanking)). When empty (the default), the score renders as plain text — there is no behavior change for existing deploys.
+
+The value is a URL template. modernGraphTool substitutes the following placeholders per row at render time. Values are URL-encoded (except `{slug}`, which keeps `-` readable).
+
+| Placeholder  | Expands to                                                            |
+|--------------|-----------------------------------------------------------------------|
+| `{brand}`    | The phone's brand                                                     |
+| `{model}`    | The phone's model                                                     |
+| `{slug}`     | `{brand}-{model}` lowercased, whitespace → `-` (matches squigRanking's `deepLink` slug format) |
+| `{fullName}` | `{brand} {model}` joined                                              |
+| `{type}`     | Always `earphone` — see note below                                    |
+
+If the template contains **no** placeholders (e.g. a Google Sheet URL), it is used verbatim — no slug or query string is appended.
+
+:::info[`{type}` on headphone deploys]
+modernGraphTool's `phone_book.json` does not record device type per phone, so `{type}` always resolves to the literal `earphone`. For a headphone-only deploy, hardcode the type instead — e.g. `RANKING_URL: "/ranking/?type=headphone#{slug}"`.
+:::
+
 ### `CDN_MODE`
 ```JavaScript
 CDN_MODE: {

--- a/src/lib/components/controls/PhoneSelector.svelte
+++ b/src/lib/components/controls/PhoneSelector.svelte
@@ -236,6 +236,7 @@
 												rel="external noopener noreferrer"
 												class="text-xs text-warning hover:underline"
 												title="Score: {phone.reviewScore}"
+												onclick={(e) => e.stopPropagation()}
 											>
 												{renderScore(phone.reviewScore)}
 											</a>

--- a/src/lib/components/controls/PhoneSelector.svelte
+++ b/src/lib/components/controls/PhoneSelector.svelte
@@ -5,6 +5,7 @@
 	import { dataProvider } from '$lib/services/data-provider.svelte.js';
 	import MetadataParser from '$lib/utils/metadata-parser.js';
 	import { getConfigValue } from '$lib/utils/config.js';
+	import { buildRankingUrl } from '$lib/utils/url-template.js';
 	import type { PhoneMetadata } from '$lib/types/data-types.js';
 	import Button from '../atoms/Button.svelte';
 	import Input from '../atoms/Input.svelte';
@@ -17,6 +18,7 @@
 		(getConfigValue('INTERFACE.ALLOW_REMOVING_PHONE_FROM_SELECTOR') as boolean) ?? true;
 	const switchPanelOnBrandClick =
 		(getConfigValue('INTERFACE.SWITCH_PHONE_PANEL_ON_BRAND_CLICK') as boolean) ?? true;
+	const rankingUrlTemplate = (getConfigValue('RANKING_URL') as string) ?? '';
 
 	// ── State ───────────────────────────────────────────────────────────────────
 
@@ -222,9 +224,26 @@
 							{#if isLoaded && (phone.reviewScore !== undefined || phone.price || phone.reviewLink || phone.shopLink)}
 								<div class="flex flex-wrap items-center gap-x-2 gap-y-1">
 									{#if phone.reviewScore !== undefined}
-										<span class="text-xs text-warning" title="Score: {phone.reviewScore}">
-											{renderScore(phone.reviewScore)}
-										</span>
+										{@const rankingHref = buildRankingUrl(rankingUrlTemplate, {
+											type: 'earphone',
+											brand: phone.brand,
+											model: phone.name
+										})}
+										{#if rankingHref}
+											<a
+												href={rankingHref}
+												target="_blank"
+												rel="external noopener noreferrer"
+												class="text-xs text-warning hover:underline"
+												title="Score: {phone.reviewScore}"
+											>
+												{renderScore(phone.reviewScore)}
+											</a>
+										{:else}
+											<span class="text-xs text-warning" title="Score: {phone.reviewScore}">
+												{renderScore(phone.reviewScore)}
+											</span>
+										{/if}
 									{/if}
 
 									{#if phone.price}

--- a/src/lib/types/data-types.ts
+++ b/src/lib/types/data-types.ts
@@ -408,6 +408,7 @@ export interface AppConfig {
   VISUALIZATION: VisualizationConfig;
   INTERFACE: InterfaceConfig;
   URL: URLConfig;
+  RANKING_URL?: string;
   LANGUAGE: LanguageConfig;
   PATH: PathConfig;
   WATERMARK: WatermarkConfig[];

--- a/src/lib/utils/url-template.spec.ts
+++ b/src/lib/utils/url-template.spec.ts
@@ -26,6 +26,14 @@ describe('buildRankingUrl', () => {
 		);
 	});
 
+	it('URL-encodes special characters in {type}', () => {
+		const tpl = '/r/?type={type}&b={brand}&m={model}&n={fullName}';
+		const ctx2 = { ...ctx, type: 'in ear/monitor' };
+		expect(buildRankingUrl(tpl, ctx2)).toBe(
+			'/r/?type=in%20ear%2Fmonitor&b=Apple&m=AirPods%20Max%20USB-C&n=Apple%20AirPods%20Max%20USB-C'
+		);
+	});
+
 	it('combines {type} and {slug} for the canonical deep-link template', () => {
 		expect(buildRankingUrl('/ranking/?type={type}#{slug}', ctx)).toBe(
 			'/ranking/?type=earphone#apple-airpods-max-usb-c'

--- a/src/lib/utils/url-template.spec.ts
+++ b/src/lib/utils/url-template.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildRankingUrl } from './url-template.js';
+
+describe('buildRankingUrl', () => {
+	const ctx = { type: 'earphone', brand: 'Apple', model: 'AirPods Max USB-C' };
+
+	it('returns null for empty, null, or undefined templates', () => {
+		expect(buildRankingUrl('', ctx)).toBeNull();
+		expect(buildRankingUrl(null, ctx)).toBeNull();
+		expect(buildRankingUrl(undefined, ctx)).toBeNull();
+	});
+
+	it('returns the template verbatim when no placeholders are present', () => {
+		const raw = 'https://docs.google.com/spreadsheets/d/abc/pubhtml';
+		expect(buildRankingUrl(raw, ctx)).toBe(raw);
+	});
+
+	it('substitutes {slug} in lowercase-hyphen form matching squigRanking buildCardId', () => {
+		expect(buildRankingUrl('/ranking/#{slug}', ctx)).toBe('/ranking/#apple-airpods-max-usb-c');
+	});
+
+	it('substitutes {type}, {brand}, {model}, {fullName} with URL-encoded values', () => {
+		const tpl = '/r/?type={type}&b={brand}&m={model}&n={fullName}';
+		expect(buildRankingUrl(tpl, ctx)).toBe(
+			'/r/?type=earphone&b=Apple&m=AirPods%20Max%20USB-C&n=Apple%20AirPods%20Max%20USB-C'
+		);
+	});
+
+	it('combines {type} and {slug} for the canonical deep-link template', () => {
+		expect(buildRankingUrl('/ranking/?type={type}#{slug}', ctx)).toBe(
+			'/ranking/?type=earphone#apple-airpods-max-usb-c'
+		);
+	});
+
+	it('leaves unknown placeholders as empty strings', () => {
+		expect(buildRankingUrl('/x/{unknown}/{slug}', ctx)).toBe('/x//apple-airpods-max-usb-c');
+	});
+});

--- a/src/lib/utils/url-template.ts
+++ b/src/lib/utils/url-template.ts
@@ -15,7 +15,7 @@ export function buildRankingUrl(
 	const slug = (brand + '-' + model).toLowerCase().replace(/\s+/g, '-');
 	const fullName = brand + ' ' + model;
 	const values: Record<string, string> = {
-		type: ctx.type ?? '',
+		type: encodeURIComponent(ctx.type ?? ''),
 		brand: encodeURIComponent(brand),
 		model: encodeURIComponent(model),
 		slug: encodeURIComponent(slug).replace(/%2D/gi, '-'),

--- a/src/lib/utils/url-template.ts
+++ b/src/lib/utils/url-template.ts
@@ -1,0 +1,25 @@
+export interface RankingUrlContext {
+	type: string;
+	brand: string;
+	model: string;
+}
+
+export function buildRankingUrl(
+	template: string | null | undefined,
+	ctx: RankingUrlContext
+): string | null {
+	if (!template) return null;
+	if (!/\{[a-zA-Z]+\}/.test(template)) return template;
+	const brand = String(ctx.brand ?? '');
+	const model = String(ctx.model ?? '');
+	const slug = (brand + '-' + model).toLowerCase().replace(/\s+/g, '-');
+	const fullName = brand + ' ' + model;
+	const values: Record<string, string> = {
+		type: ctx.type ?? '',
+		brand: encodeURIComponent(brand),
+		model: encodeURIComponent(model),
+		slug: encodeURIComponent(slug).replace(/%2D/gi, '-'),
+		fullName: encodeURIComponent(fullName)
+	};
+	return template.replace(/\{([a-zA-Z]+)\}/g, (_, k) => (values[k] != null ? values[k] : ''));
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows the review score in the `PhoneSelector` component to be optionally wrapped in a link to a configurable ranking page. The ranking URL is defined via a new `RANKING_URL` template in the configuration, supporting per-device deep linking with placeholders for brand, model, type, etc. The implementation is accompanied by documentation and unit tests.

**Feature: Configurable Ranking URL for Review Scores**

* Added a new `RANKING_URL` configuration option in `defaults/config.js` to allow admins to specify a URL template for per-device ranking pages, with support for placeholders such as `{brand}`, `{model}`, `{slug}`, `{fullName}`. If left empty, the review score remains plain text (legacy behavior).
* Updated documentation in `docs/docs/guide-for-admins/customize-page.mdx` to explain the new `RANKING_URL` option, its usage, supported placeholders, and behavior for headphone-only deploys.
* Extended the `AppConfig` type to include the optional `RANKING_URL` property.

**Implementation: Linking Review Scores**

* Modified `PhoneSelector.svelte` to use the new `RANKING_URL` config: if set, review scores are rendered as links to the ranking page with appropriate placeholder substitution; otherwise, the score remains plain text. [[1]](diffhunk://#diff-90ca1ef77b0565faba2662dd53a05bd98189f42004b2eb53a5aaaee25de50d55R8) [[2]](diffhunk://#diff-90ca1ef77b0565faba2662dd53a05bd98189f42004b2eb53a5aaaee25de50d55R21) [[3]](diffhunk://#diff-90ca1ef77b0565faba2662dd53a05bd98189f42004b2eb53a5aaaee25de50d55R227-R247)

**Utilities and Testing**

* Added a new utility function `buildRankingUrl` in `url-template.ts` to handle placeholder substitution for ranking URLs, including slug formatting and URL encoding.
* Added comprehensive unit tests for `buildRankingUrl` to ensure correct behavior for placeholder substitution, verbatim URLs, and edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review scores in the device selector can be rendered as clickable external ranking links via a new configurable RANKING_URL template.

* **Documentation**
  * Added docs for the RANKING_URL option, detailing template placeholders, placeholder semantics, and URL-encoding rules.

* **Tests**
  * Added automated tests covering template substitution, slug formatting, URL-encoding, and handling of empty/unknown templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->